### PR TITLE
Python 3.2 fix

### DIFF
--- a/core.py
+++ b/core.py
@@ -71,7 +71,7 @@ class Runner:
                 return self.pipe.returncode
 
             def fail(self, lastMsg=None):
-                errorOutput = self.pipe.stderr.readall().decode('utf-8').strip()
+                errorOutput = self.pipe.stderr.read(-1).decode('utf-8').strip()
                 if errorOutput:
                     print(errorOutput)
                 print('Command "%s" exited with code %s' % (cmd, self.poll()))


### PR DESCRIPTION
On my installation of python 3.2 it seems readall() is not implemented -- i get an Exception here. With read(-1) it works fine. From the documentation read(-1) is, in fact the same as readall.
