### PR TITLE
Projects with path in common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 __pycache__/
 *.pyc
+
+# Vim tmp artifacts
+*.swp
+*.swo
+
+# ctags file:
+tags

--- a/clone.py
+++ b/clone.py
@@ -40,11 +40,17 @@ class clone(Command):
         workfold = tf('workfold .')
         pwd = os.path.abspath('.')
         folderMaps = re.findall('^\s*(\$[^:]+): (\S+)$', workfold, re.M)
-        serverRoot, localRoot = [(s, l) for s, l in folderMaps if os.path.commonprefix((l, pwd)) == l][0]
-        if localRoot != pwd:
-            print('You must be in the mapped local folder to use "git tf clone":')
+
+        serverAndLocalRootCandidates = [(s, l) for s, l in folderMaps if os.path.commonprefix((l, pwd)) == l]
+        for serverRoot, localRoot in serverAndLocalRootCandidates:
+            if localRoot == pwd:
+                return
+
+        print('You must be in a mapped local folder to use "git tf clone":')
+        for serverRoot, localRoot in serverAndLocalRootCandidates:
             printIndented(localRoot)
-            fail()
+
+        fail()
 
     def _setupEmail(self):
         def checkEmail(email):


### PR DESCRIPTION
If a project named "aaa" is imported, then you import
another named "aaa-bbb" and then try to git-tf clone "aaa-bbb"
it failed saying that you must be in a local path where "aaa"
was.

Thats because:

/path/to/workspace/aaa
/path/to/workspace/aaa-bbb

have a common os.path.commonprefix. And every run of clone in
/path/to/workspace/aaa-bbb keeps complaining that you need to be
in /path/to/workspace/aaa.
