### PR TITLE
Fix when TFS commit consists only of spaces

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -71,7 +71,7 @@ class fetch(Command):
 
                     if verbose:
                         print('Committing to Git...')
-                    comment = cs.comment
+                    comment = cs.comment.trim() if cs.comment else None
                     if not comment:
                         if verbose:
                             print('The comment is empty. Using changeset number as a comment')


### PR DESCRIPTION
If cs.comment is " " then comment will be " " but git does not
accept this -- instead it fails with the following error message:

"Aborting due to empty commit message"

The fix is to trim() the message.
