### PR TITLE
Numer of reported TFS commits for status and log fixed.

### DIFF
--- a/log.py
+++ b/log.py
@@ -15,7 +15,7 @@ class log(Command):
         gitArgs = ', '.join(map(lambda s: '\'' + s + '\'', self.args.gitArgs))
 
         endMarker = '</git.tf>'
-        process = git.start('log {} --format="%h\t%an\t%at\t%s%n%N%n{}"'.format(gitArgs, endMarker))
+        process = git.start('log {} --first-parent --format="%h\t%an\t%at\t%s%n%N%n{}"'.format(gitArgs, endMarker))
         for line in iter(process.readline, None):
             (commit, author, date, comment) = line.split('\t', 3)
             date = datetime.datetime.fromtimestamp(int(date)).strftime('%x %X')

--- a/status.py
+++ b/status.py
@@ -10,7 +10,7 @@ class status(Command):
         self.switchBranch('master')
 
     def _run(self):
-        commits = git('log tfs.. --format="%h %s"').splitlines()
+        commits = git('log tfs.. --format="%h %s" --first-parent').splitlines()
         if not commits:
             print('There are no commits to be pushed to TFS')
             return


### PR DESCRIPTION
When computing the commits to be pushed on TFS the following command
is executed:

commits = git('log %s.. --format=%%H master --reverse --first-parent'
              % lastCommit).splitlines()

But for "git tf log" and "git tf status" there was no --first-parent
option. Because of this the number of commits reported with "tf status"
and "tf log" consisted of commits in the current branch and commits from
all merged branches (event when the merge was not fast-forward). The
actual TFS commits are only the ones from the current branch.
