### PR TITLE
Content rename fix

### DIFF
--- a/push.py
+++ b/push.py
@@ -76,6 +76,7 @@ class push(Command):
                             os.rename(dest, src)
                         try:
                             tfmut('rename {}', joinFiles(files))
+                            tfmut('checkout {}', files[1])
                         except:
                             if not dryRun:
                                 os.rename(src, dest)


### PR DESCRIPTION
When a file gets renamed and changed (eg. class rename)
git-tf only renamed file and didn't changed the content
