### PR TITLE
Bad substitution error.

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -77,6 +77,7 @@ class fetch(Command):
                             print('The comment is empty. Using changeset number as a comment')
                         comment = str(cs.id)
                     comment = comment.replace('"', '\\"')
+                    comment = comment.replace('$', '\\$')
                     git('add -A .', dryRun=dryRun)
                     commitArgs = r'commit --allow-empty -m "%s" --author="%s <%s@%s>" --date="%s"' % \
                                  (comment, cs.committer, cs.committer, domain, cs.dateIso)

--- a/fetch.py
+++ b/fetch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from core import *
 import re
+import tempfile
 
 _allFilesUpToDate = 'All files up to date.'
 
@@ -76,12 +77,13 @@ class fetch(Command):
                         if verbose:
                             print('The comment is empty. Using changeset number as a comment')
                         comment = str(cs.id)
-                    comment = comment.replace('"', '\\"')
-                    comment = comment.replace('$', '\\$')
                     git('add -A .', dryRun=dryRun)
-                    commitArgs = r'commit --allow-empty -m "%s" --author="%s <%s@%s>" --date="%s"' % \
-                                 (comment, cs.committer, cs.committer, domain, cs.dateIso)
-                    git(commitArgs, output=verbose, dryRun=dryRun)
+                    with tempfile.NamedTemporaryFile('w') as tempFile:
+                        tempFile.file.write(comment)
+                        tempFile.file.close()
+                        commitArgs = r'commit --allow-empty -F %s --author="%s <%s@%s>" --date="%s"' % \
+                                     (tempFile.name, cs.committer, cs.committer, domain, cs.dateIso)
+                        git(commitArgs, output=verbose, dryRun=dryRun)
                     git('notes add -m %s' % cs.id, dryRun=dryRun)
                     if not verbose:
                         print('Commit:', git('log -1 --format=%h'))

--- a/push.py
+++ b/push.py
@@ -4,6 +4,7 @@ import shutil
 import re
 import repair
 import wi
+import tempfile
 
 
 class push(Command):
@@ -89,15 +90,17 @@ class push(Command):
 
             if verbose:
                 print('Checking in...')
-            comment = git('log -1 --format=%s%n%b').strip().replace('"', '\\"')
-            comment = comment.replace('$', '\\$')
+            comment = git('log -1 --format=%s%n%b').strip()
             workitems = git('notes --ref=%s show %s' % (wi.noteNamespace, hash), errorValue='')
             if workitems:
                 workitems = '"-associate:%s"' % workitems
-            checkin = tf(('checkin "-comment:{}" -recursive {} .', comment, workitems),
-                allowedExitCodes=[0, 1],
-                output=verbose,
-                dryRun=dryRun and 'Changeset #12345')
+            with tempfile.NamedTemporaryFile('w') as tempFile:
+                tempFile.file.write(comment)
+                tempFile.file.close()
+                checkin = tf(('checkin "-comment:@{}" -recursive {} .', tempFile.name, workitems),
+                    allowedExitCodes=[0, 1],
+                    output=verbose,
+                    dryRun=dryRun and 'Changeset #12345')
             changeSetNumber = re.search(r'^Changeset #(\d+)', checkin, re.M)
             if not changeSetNumber:
                 fail('Check in failed.')

--- a/push.py
+++ b/push.py
@@ -90,6 +90,7 @@ class push(Command):
             if verbose:
                 print('Checking in...')
             comment = git('log -1 --format=%s%n%b').strip().replace('"', '\\"')
+            comment = comment.replace('$', '\\$')
             workitems = git('notes --ref=%s show %s' % (wi.noteNamespace, hash), errorValue='')
             if workitems:
                 workitems = '"-associate:%s"' % workitems
@@ -105,7 +106,7 @@ class push(Command):
                 print('Changeset number:', changeSetNumber)
         except:
             if not dryRun:
-                repairer = repair()
+                repairer = repair.repair()
                 repairer.checkoutBranch = 'tfs'
                 repairer._run()
             raise


### PR DESCRIPTION
When pushing or fetching commits with "${ }" in message the linux/unix
shell fails with the message "Bad substitution error". This is because
"${ }" has a special meaning in shell strings. For example:

$ echo "${ }"
bash: ${ }: bad substitution

Note: this fix works for linux. Somebody on Windows should try that this
don't cause any problems. If yes -- it should be included in the changes
Nodirt is making in the win branch.
