### PR TITLE
Fix: '--show-notes' is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ analogous to _origin_.
 Each git commit synchronized with TFS has a [git note](http://schacon.github.com/git/git-notes.html) in the _tf_
 namespace. Each note has a TFS changeset number. To see the notes run
 
-    $ git log --show-notes=tf
+    $ git log --notes=tf
 
 Associated workitems IDs are stored in the _tf.wi_ note namespace.
 


### PR DESCRIPTION
In the "How it Works" section the commando to display the notes in the _tf_ namespace is
`$ git log --show-notes=tf`

_--show-notes_ is deprecated (http://man.github.com/git/git-log.html). Change the command to:
`$ git log --notes=tf`
