### PR TITLE
Vim artifacts in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 __pycache__/
 *.pyc
+
+# Temporary (g)vim artifacts:
+*.swp
+*.swo
+tags


### PR DESCRIPTION
I use vim for my python development. Vim creates .sw\* temporary files
that are detected with git status, but I don't want to commit them.
The tags file created with the ctags command is similar (not exactly
a vim artifact but used to navigate the project with vim).

This shouldn't cause any problems for anybody.

PS. You don't have to use HJKL with vim. Arrow keys work, too :)
